### PR TITLE
fix(rx-utils): createHandler void fix

### DIFF
--- a/packages/rx-utils/src/__tests__/create-handler.utils.spec.ts
+++ b/packages/rx-utils/src/__tests__/create-handler.utils.spec.ts
@@ -1,0 +1,24 @@
+import { createHandler } from '../create-handler.utils';
+import { Endomorphism, Lazy } from 'fp-ts/lib/function';
+
+describe('create-handler.utils.ts', function() {
+	describe('createHandler', function() {
+		it('should not fail', function() {
+			const a = createHandler();
+			const af1: Lazy<void> = a.handle; // adds possibility to use handle as Lazy<void>
+			const af2: Endomorphism<void> = a.handle; // keeps possibility to use as Endomorphism<void>
+			af1(); // no argument is needed
+			af2(undefined); // still can pass undefined
+
+			const b = createHandler<void>(); // the same as above
+			const bf1: Lazy<void> = b.handle;
+			const bf2: Endomorphism<void> = b.handle;
+			bf1();
+			bf2(undefined);
+
+			const c = createHandler<string>();
+			const cf3: (a: string) => void = c.handle; // that's correct
+			cf3(''); // correct
+		});
+	});
+});

--- a/packages/rx-utils/src/create-handler.utils.ts
+++ b/packages/rx-utils/src/create-handler.utils.ts
@@ -10,6 +10,6 @@ export const createHandler = <A = void>(): THandler<A> => {
 	const value = new Subject<A>();
 	return {
 		value$: value.asObservable(),
-		handle: value.next as THandle<A>,
+		handle: value.next.bind(value) as THandle<A>,
 	};
 };

--- a/packages/rx-utils/src/create-handler.utils.ts
+++ b/packages/rx-utils/src/create-handler.utils.ts
@@ -1,16 +1,15 @@
 import { Observable, Subject } from 'rxjs';
 
+export type THandle<A> = A extends void ? ((a?: void) => void) : ((a: A) => void);
 export type THandler<A> = {
-	readonly handle: (value: A) => void;
 	readonly value$: Observable<A>;
+	readonly handle: THandle<A>;
 };
 
 export const createHandler = <A = void>(): THandler<A> => {
 	const value = new Subject<A>();
-	const handle = (val: A) => value.next(val);
-
 	return {
 		value$: value.asObservable(),
-		handle,
+		handle: value.next as THandle<A>,
 	};
 };


### PR DESCRIPTION
createHandler().handle now can be applied to the constant with type Lazy<void>
fixes #177

gist with example
https://gist.github.com/scink/7d7eedaa1634db0cf0fb916d28baeeae