### PR TITLE
fix(rx-utils): fix createHandler signature

### DIFF
--- a/packages/rx-utils/src/__tests__/create-handler.utils.spec.ts
+++ b/packages/rx-utils/src/__tests__/create-handler.utils.spec.ts
@@ -1,37 +1,33 @@
 import { createHandler } from '../create-handler.utils';
 import { Endomorphism, Lazy } from 'fp-ts/lib/function';
-import { constVoid } from 'fp-ts/lib/function';
 
 interface VoidThunk<A> {
 	(a: A): void;
 }
-
 describe('create-handler.utils.ts', function() {
 	describe('createHandler', function() {
 		it('should not fail', function() {
 			const a = createHandler();
-			const af1: Lazy<void> = a.handle; // adds possibility to use handle as Lazy<void>
-			const af2: Endomorphism<void> = a.handle; // keeps possibility to use as Endomorphism<void>
+			const af1: Lazy<void> = a.handle;
+			const af2: Endomorphism<void> = a.handle;
 			a.handle();
-			a.handle(undefined);
-			a.handle(constVoid());
-			af1(); // no argument is needed
-			af2(undefined); // still can pass undefined
+			af1();
+			af2(undefined);
 
-			const b = createHandler<void>(); // the same as above
+			const b = createHandler<void>();
 			b.handle();
-			b.handle(undefined);
-			b.handle(constVoid());
 			const bf1: Lazy<void> = b.handle;
 			const bf2: Endomorphism<void> = b.handle;
 			bf1();
 			bf2(undefined);
 
 			const c = createHandler<string>();
+			c.handle('');
 			const cf3: VoidThunk<string> = c.handle;
 			cf3('');
 
 			const d = createHandler<boolean>();
+			d.handle(true);
 			const df1: VoidThunk<boolean> = d.handle;
 			df1(true);
 

--- a/packages/rx-utils/src/create-handler.utils.ts
+++ b/packages/rx-utils/src/create-handler.utils.ts
@@ -1,18 +1,23 @@
 import { Observable, Subject } from 'rxjs';
 
-export interface THandle<A> {
-	(): void;
-	(a: A): void;
+interface HandlerVoid {
+	readonly value$: Observable<void>;
+	readonly handle: () => void;
 }
-export type THandler<A> = {
+interface HandlerValue<A> {
 	readonly value$: Observable<A>;
-	readonly handle: THandle<A>;
-};
+	readonly handle: (a: A) => void;
+}
+interface CreateHandler {
+	(): HandlerVoid;
+	<A extends void>(): HandlerVoid;
+	<A>(): HandlerValue<A>;
+}
 
-export const createHandler = <A = void>(): THandler<A> => {
+export const createHandler: CreateHandler = <A>() => {
 	const value = new Subject<A>();
 	return {
 		value$: value.asObservable(),
-		handle: value.next.bind(value) as THandle<A>,
+		handle: value.next.bind(value),
 	};
 };


### PR DESCRIPTION
had to delete `THandle` and `THandler` types because TS forms union type incorrectly for the handler. it is `(a: true) => void | (a: false) => void` instead of `(a: boolean) => void`.
fixes #183 

http://www.typescriptlang.org/play/#code/JYOwLgpgTgZghgYwgAgCoAs4gCYBsIBqA9sNsgN4BQAkABRwD8AXMgG4nYCUL7pA3JQC+lUJFiIUqABJY8hOLgCuEADwBBAHwUa9Fmu5sOA4QHoTyCAA8ADkShhkYAJ7XJMnPnXIAvIdJbfNQtLSBwAZz8yBmR6ZkjOHy1eMhZdZH1EyIErW3tHFzdZTyDfZIC0TA9CDmQAHzR3OQIFZXUNAUpsCARcOCgUBCIQMIc4Fmki1TKBQeHRsZiFkahQAHME7ySa3zg+ZDMLKCg7SlmR5DgAI1SNrdIfC72DsPQiRVwyS5QwxQQkMLCpyG50QqQWihwEBgoAgXEyyQeu325hebw+yC+yB+fwgAMonW6vX6yDODmuDUmKmWa3aQLmGIWaWpIHW8O2GKeKNe70+31+-0BpIx5Not0iD0unMOxygdPOlwQYJYEK60JAsLFCN8kuR0pOBJ6fQGwIciopVRmJpJjKWYBWLM17IQUugMrlppFjvuvmdutRPIxfJxeKFfyVyBVUJhcM24p9Uv96Mx2IF+K6huJQuw40ankuRCI+CwtKzNpYzNZsa1yGwLqOJyznrZ3prdbdWbNaUjao1zbIvlrutdDat2GzixY+cLECwXv7rb93KTQYFQA

BREAKING CHANGE: remove THandle and THandler types