### PR TITLE
replace deprecated jsxBracketSameLine

### DIFF
--- a/packages/lint/.prettierrc.json
+++ b/packages/lint/.prettierrc.json
@@ -1,6 +1,6 @@
 {
   "bracketSpacing": true,
-  "jsxBracketSameLine": true,
+  "bracketSameLine": true,
   "parser": "typescript",
   "printWidth": 120,
   "semi": true,


### PR DESCRIPTION
from 2.4 version of Prettier package jsxBracketSameLine is deprecated: https://prettier.io/blog/2021/09/09/2.4.0.html