### PR TITLE
parentheses for arrow function argument avoid prettier-eslint collision

### DIFF
--- a/packages/lint/.eslintrc.json
+++ b/packages/lint/.eslintrc.json
@@ -57,7 +57,7 @@
 		"@typescript-eslint/type-annotation-spacing": "error",
 		"@typescript-eslint/unified-signatures": "error",
 		"jsdoc/check-alignment": "error",
-		"arrow-parens": ["error", "as-needed"],
+		"arrow-parens": ["error"],
 		"spaced-comment": "off",
 		"capitalized-comments": "off",
 		"comma-dangle": "off",


### PR DESCRIPTION
By default prettier set parentheses around arrow function [type def](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/prettier/index.d.ts#L168)
so to avoid conflicts need to remove rule from es-lint