### PR TITLE
Feature/add test id to selectbox anchor

### DIFF
--- a/packages/react-kit/src/components/Selectbox/SelectboxAnchor.tsx
+++ b/packages/react-kit/src/components/Selectbox/SelectboxAnchor.tsx
@@ -18,6 +18,7 @@ export type TFullSelectboxAnchorProps = Omit<TButtonProps, 'theme'> & {
 	caretIcon?: ReactNode;
 	value?: ReactText | ReactText[];
 	valueText?: ReactNode;
+	testId?: string;
 };
 
 @PURE
@@ -33,6 +34,7 @@ class RawSelectboxAnchor extends React.Component<TFullSelectboxAnchorProps> {
 			caretIcon,
 			onClick,
 			isOpened,
+			testId,
 		} = this.props;
 
 		const buttonTheme = {
@@ -47,7 +49,8 @@ class RawSelectboxAnchor extends React.Component<TFullSelectboxAnchorProps> {
 				isDisabled={isDisabled}
 				isLoading={isLoading}
 				isPrimary={isPrimary}
-				theme={buttonTheme}>
+				theme={buttonTheme}
+				data-test-id={testId}>
 				<div className={theme.content}>
 					<div className={theme.text}>{valueText}</div>
 					<div className={theme.caret}>{caretIcon}</div>

--- a/packages/rx-utils/package.json
+++ b/packages/rx-utils/package.json
@@ -24,11 +24,12 @@
     "lint:fix": "yarn lint --fix",
     "test": "tsc --noEmit && jest",
     "build": "tsc -p ./tsconfig.build.json --outDir ./dist",
-    "clean": "rm -rf ./dist",
+    "clean": "dx-tools clean dist",
     "prepare": "yarn clean && yarn build",
     "watch": "yarn build --watch --incremental"
   },
   "dependencies": {
+    "@devexperts/tools": "^1.0.0-alpha.14",
     "@devexperts/utils": "^1.0.0-alpha.14",
     "@types/query-string": "^5.1.0",
     "query-string": "^6.1.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -9,7 +9,7 @@
     "lint:fix": "yarn lint --fix",
     "test": "yarn lint && tsc --noEmit && jest",
     "build": "tsc -p ./tsconfig.build.json --outDir ./dist",
-    "clean": "rm -rf ./dist",
+    "clean": "dx-tools clean dist",
     "prepare": "yarn clean && yarn build",
     "start": "yarn watch",
     "watch": "yarn build --watch --incremental"
@@ -28,6 +28,7 @@
   },
   "homepage": "https://github.com/devexperts/dx-platform#readme",
   "dependencies": {
+    "@devexperts/tools": "^1.0.0-alpha.14",
     "tslib": "^1.10.0",
     "typelevel-ts": "^0.3.5"
   },


### PR DESCRIPTION
# Changes

1. Add data-test-id to selectbox anchor to allow programmatic access during e2e
2. Fix build on windows using platform independent clean tasks